### PR TITLE
Fix for error: 'tuple' object is not callable

### DIFF
--- a/analysis_practice.ipynb
+++ b/analysis_practice.ipynb
@@ -92,7 +92,7 @@
    "outputs": [],
    "source": [
     "# shows the number of rows, columns in the data table\n",
-    "data.shape()"
+    "data.shape"
    ]
   },
   {


### PR DESCRIPTION
Just a small correction. 

Thanks for the excellent tutorial.